### PR TITLE
Support initial specification of centroids

### DIFF
--- a/lib/KMeansEngine.js
+++ b/lib/KMeansEngine.js
@@ -9,6 +9,7 @@ class KMeansEngine {
     this.k = this.options.k;
     this.debug = this.options.debug || false;
     this.maxIterations = this.options.maxIterations;
+    this.initialCentroids = this.options.initialCentroids;
     this.callback = callback;
 
     this.validateInput();
@@ -41,6 +42,21 @@ class KMeansEngine {
         (!Number.isInteger(this.maxIterations) || (this.maxIterations <= 0))) {
       throw new Error('Max iterations should be a positive integer');
     }
+
+    if (this.initialCentroids !== undefined) {
+      if (!_.isArray(this.initialCentroids) || (this.initialCentroids.length !== this.k)) {
+        throw new Error('Initial centroids should be array of length equal to cluster size')
+      } else {
+        // Initial centroids  should be array of objects
+        for (let i = 0; i < this.initialCentroids.length; i += 1) {
+          const c = this.initialCentroids[i];
+
+          if (!_.isObject(c) || _.isArray(c) || _.isFunction(c)) {
+            throw new Error('Centroids should be array of objects');
+          }
+        }
+      }
+    }
   }
 
   init() {
@@ -52,11 +68,18 @@ class KMeansEngine {
     // map to vector object
     this.vectors = this.vectors.map(vector => new Vector(vector));
 
-    const randNums = KMeansEngine.getRandomSequence(0, this.vectors.length - 1, this.k);
 
-    // randomly pick a vector to be the centroid
-    for (let i = 0; i < this.k; i += 1) {
-      this.clusters.push(new Cluster(this.vectors[randNums[i]]));
+    if (this.initialCentroids === undefined) {
+      const randNums = KMeansEngine.getRandomSequence(0, this.vectors.length - 1, this.k);
+      // randomly pick a vector to be the centroid
+      for (let i = 0; i < this.k; i += 1) {
+        this.clusters.push(new Cluster(this.vectors[randNums[i]]));
+      }
+    } else {
+      // set things up with the initial centroids
+      for (let i = 0; i < this.k; i += 1) {
+        this.clusters.push(new Cluster(new Vector(this.initialCentroids[i])));
+      }
     }
 
     this.showLog(`Number of vectors: ${this.vectors.length}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kmeans-engine",
-  "version": "1.2.1",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/KMeansEngine.js
+++ b/test/KMeansEngine.js
@@ -1,3 +1,4 @@
+const _ = require('underscore');
 const chai = require('chai');
 
 const should = chai.should();
@@ -46,6 +47,28 @@ describe('KMeansEngine', () => {
       (() => {
         kmeans.clusterize(set1, { k: 3, maxIterations: -1 }, () => {});
       }).should.to.throw('Max iterations should be a positive integer');
+    });
+
+    it('should only accept initial centroids as array of objects', () => {
+      (() => {
+        kmeans.clusterize(set1, { k: 2, initialCentroids: {} }, () => {});
+      }).should.to.throw('Initial centroids should be array of length equal to cluster size');
+
+      (() => {
+        kmeans.clusterize(set1, { k: 2, initialCentroids: [() => {}, () => {}] }, () => {});
+      }).should.to.throw('Centroids should be array of objects');
+
+      (() => {
+        kmeans.clusterize(set1, { k: 2, initialCentroids: ['abc', 'def'] }, () => {});
+      }).should.to.throw('Centroids should be array of objects');
+
+      (() => {
+        kmeans.clusterize(set1, { k: 2, initialCentroids: [123, 456.7] }, () => {});
+      }).should.to.throw('Centroids should be array of objects');
+
+      (() => {
+        kmeans.clusterize(set1, { k: 2, initialCentroids: [true, true] }, () => {});
+      }).should.to.throw('Centroids should be array of objects');
     });
   });
 
@@ -97,6 +120,37 @@ describe('KMeansEngine', () => {
         res.iterations.should.to.be.equal(1);
 
         done();
+      });
+    });
+
+    it('should return same result given same initial centroids', (done) => {
+      const initialCentroids = [{x: 1, y: 0}, {x: 0, y: 1}, {x: 1, y: 1}];
+      kmeans.clusterize(set2, { k: 3, maxIterations: 1, initialCentroids: initialCentroids}, (err1, res1) => {
+        should.not.exist(err1);
+        res1.should.to.have.property('iterations');
+        res1.should.to.have.property('clusters');
+
+        res1.clusters.should.to.have.lengthOf(3);
+        res1.clusters.forEach((cluster1) => {
+          cluster1.should.to.have.property('centroid');
+          cluster1.should.to.have.property('vectorIds');
+        });
+
+        kmeans.clusterize(set2, { k: 3, maxIterations: 1, initialCentroids: initialCentroids }, (err2, res2) => {
+          should.not.exist(err2);
+          res2.should.to.have.property('iterations');
+          res2.should.to.have.property('clusters');
+
+          res2.clusters.should.to.have.lengthOf(3);
+          res2.clusters.forEach((cluster2) => {
+            cluster2.should.to.have.property('centroid');
+            cluster2.should.to.have.property('vectorIds');
+          });
+
+          res1.should.deep.equal(res2);
+          done();
+
+        });
       });
     });
   });

--- a/test/KMeansEngine.js
+++ b/test/KMeansEngine.js
@@ -148,8 +148,8 @@ describe('KMeansEngine', () => {
           });
 
           res1.should.deep.equal(res2);
-          done();
 
+          done();
         });
       });
     });


### PR DESCRIPTION
Hi there - found you on npm and the package is incredibly easy to use - thanks so much for creating it.

One thing I was looking for was a way to specify the initial centroids, mainly as a way to remove the randomness and to build up the centroids over time.

Would love your thoughts on this change - I know you have "enhance initial centroid picking" as a To-Do item - so maybe this could be a first step towards that?
